### PR TITLE
recovery: switch invocation button from power to volume up key

### DIFF
--- a/recovery/init.sh
+++ b/recovery/init.sh
@@ -37,8 +37,8 @@ if [ -s /recovery$RAMDISK ]; then
 
         # key check
         $BUSYBOX mkdir -m 755 /dev/input
-        $BUSYBOX mknod -m 660 /dev/input/event0 c 13 64
-        $BUSYBOX cat /dev/input/event0 > $KEYCHECK&
+        $BUSYBOX mknod -m 660 /dev/input/event1 c 13 65
+        $BUSYBOX cat /dev/input/event1 > $KEYCHECK&
         $BUSYBOX sleep 3
         kill $!
         if [ -s $KEYCHECK ]; then


### PR DESCRIPTION
Previously with kernel_sony_msm8x60, event0 was associated to "volume up" key.
With the switch to kernel_msm, event0 is now associated to "power" key and event1 to "volume up" key.

It is "usually more standard" to use "volume up" key to invoke the recovery during the boot.

This is the goal of this patch. So more a user friendly fix than a bug fix.
